### PR TITLE
[MRG] Building databases from assembly_summary.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# sourmash databases
+
+## Setup
+
+All processing is performed using the conda environment specified in `environment.yml`.
+To build and activate this environment run:
+
+```bash
+conda env create --force --file environment.yml
+
+conda activate sourmash_databases
+```

--- a/Snakefile.assembly
+++ b/Snakefile.assembly
@@ -6,7 +6,8 @@ configfile: "config.assembly.yml"
 rule all:
   input:
     expand("outputs/sbt/{db}-{domain}-x{bfsize}-k{ksize}.sbt.zip", db=config['db'], ksize=config['db_ksizes'], domain=config['domains'], bfsize=config['bfsize']),
-    expand("outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz", db=config['db'], domain=config['domains'], ksize=config['db_ksizes'])
+    expand("outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz", db=config['db'], domain=config['domains'], ksize=config['db_ksizes']),
+    expand("outputs/taxid4index/{db}-{domain}.csv", db=config['db'], domain=config['domains'])
 
 
 def sigs_in_catalog(w):
@@ -210,7 +211,17 @@ rule lca_lineage_csv:
     make_lineage_csv = "scripts/make-lineage-csv.py",
     taxonomy = expand("outputs/taxonomy/{file}.dmp", file=('nodes', 'names')),
   shell: """
-    {input.make_lineage_csv} {input.taxonomy} <({input.make_acc_taxid_mapping} {input.summary}) -o {output}
+    {input.make_lineage_csv} {input.taxonomy} \
+        <({input.make_acc_taxid_mapping} --strip-version {input.summary}) -o {output}
+  """
+
+rule taxid4index:
+  output: "outputs/taxid4index/{db}-{domain}.csv",
+  input:
+    summary = "outputs/assembly_stats/{domain}/assembly_summary_{db}.txt.gz",
+    make_acc_taxid_mapping = "scripts/make-acc-taxid-mapping.py",
+  shell: """
+    {input.make_acc_taxid_mapping} {input.summary} > {output}
   """
 
 rule download_taxonomy:

--- a/Snakefile.assembly
+++ b/Snakefile.assembly
@@ -3,21 +3,23 @@ import random
 
 configfile: "config.assembly.yml"
 
-# load in list of genomes by domain
-DOMAINS=config['domains']
-
-###
-
 # rule 'all' builds specific SBTs.
 rule all:
   input:
     expand("outputs/sbt/{db}-{domain}-x{bfsize}-k{ksize}.sbt.zip", db=config['db'], ksize=config['db_ksizes'], domain=config['domains'], bfsize=config['bfsize']),
 #    expand("outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz", db=config['db'], domain=config['domains'], ksize=config['db_ksizes'])
 
+
+def sigs_in_catalog(w):
+    with checkpoints.catalog.get(domain=w.domain, db=w.db).output[0].open('r') as f:
+        return [l.strip() for l in f.readlines()]
+
+
 rule sbt:
   output: "outputs/{index}/{db}-{domain}-x{bfsize}-k{ksize}.sbt.zip"
   input:
-    catalog = "outputs/catalog/{domain}/{db}.txt"
+    catalog = "outputs/catalog/{domain}/{db}.txt",
+    sigs = sigs_in_catalog
   params:
     ksize="{ksize}",
     db="{db}",
@@ -62,14 +64,16 @@ rule download_catalog:
     date +%Y%m%d > {output.generated}
   """
 
-rule catalog:
+checkpoint catalog:
   output: "outputs/catalog/{domain}/{db}.txt"
   input: "outputs/assembly_stats/{domain}/assembly_summary_{db}.txt.gz"
+  params:
+    domain = "{domain}"
   run:
       import csv
       import gzip
 
-      basedir = config['sig_location']
+      basedir = config['sig_store']
 
       with gzip.open(input[0], 'rt') as fp:
           fp.readline() # skip first line
@@ -79,4 +83,78 @@ rule catalog:
           with open(output[0], 'w') as fout:
               for row in data:
                   accession = row['assembly_accession']
-                  fout.write(f"{basedir}/{accession}.sig\n")
+                  path = f"{basedir}/{accession}.sig"
+                  if not os.path.exists(path):
+                      # let's calculate locally
+                      path = f"outputs/sigs/{params.domain}/{accession}.sig"
+                  fout.write(path + '\n')
+
+
+## Rules for computing signatures not found in config['sig_store']
+
+def url_for_accession(accession):
+    db, acc = accession.split("_")
+    number, version = acc.split(".")
+    number = "/".join([number[pos:pos + 3] for pos in range(0, len(number), 3)])
+    url = f"ftp://ftp.ncbi.nlm.nih.gov/genomes/all/{db}/{number}"
+
+    all_names = shell(f"curl -l {url}/", read=True).split('\n')
+
+    full_name = None
+    for name in all_names:
+        db_, acc_, _ = name.split("_")
+        if db_ == db and acc == acc_:
+            full_name = name
+            break
+
+    url = "https" + url[3:]
+    return f"{url}/{full_name}/{full_name}_genomic.fna.gz"
+
+    # TODO: alternative is read assembly_summary for asm_name
+    #return f"{url}/{accession}_{asm_name}"
+
+
+def name_for_accession(domain, accession):
+    import csv
+    import gzip
+
+    if accession[:3] == "GCA":
+        db = "genbank"
+    else:
+        db = "refseq"
+    summary = f"outputs/assembly_stats/{domain}/assembly_summary_{db}.txt.gz"
+
+    with gzip.open(summary, 'rt') as fp:
+        fp.readline() # skip first line
+        fp.read(2) # skip initial comment in header
+        data = csv.DictReader(fp, delimiter='\t')
+        for row in data:
+            if row['assembly_accession'] == accession:
+                name_parts = [row["assembly_accession"], " ", row['organism_name']]
+                if row['infraspecific_name']:
+                    name_parts += [" ", row['infraspecific_name']]
+                name_parts += [', ', row['asm_name']]
+                return "".join(name_parts)
+        # If we get here, then the accession wasn't in the summary.
+        raise ValueError("Accession not in this summary file!")
+
+
+# TODO: fix the input, need to calculate genbank/refseq from accession
+rule compute:
+  output: "outputs/sigs/{domain}/{accession}.sig"
+  input:
+    genbank="outputs/assembly_stats/{domain}/assembly_summary_genbank.txt.gz",
+    refseq="outputs/assembly_stats/{domain}/assembly_summary_refseq.txt.gz",
+  params:
+    ksizes=lambda w: ",".join(str(k) for k in config["db_ksizes"]),
+    scaled=1000,
+    name=lambda w: name_for_accession(w.domain, w.accession),
+    url_path=lambda w: url_for_accession(w.accession),
+  shell: """
+    sourmash compute -k {params.ksizes} \
+      --scaled {params.scaled} \
+      --track-abundance \
+      --name {params.name:q} \
+      -o {output} \
+      <(curl {params.url_path} | zcat)
+  """

--- a/Snakefile.assembly
+++ b/Snakefile.assembly
@@ -48,6 +48,8 @@ rule lca:
     domain="{domain}",
   benchmark: "benchmark/lca/{db}-{domain}-k{ksize}.txt"
   shell: """
+    mkdir -p outputs/lca/reports/
+
     sourmash lca index \
       -k {params.ksize} \
       --scaled 10000 \
@@ -200,7 +202,8 @@ rule download_lca_scripts:
     taxdump_utils = "scripts/ncbi_taxdump_utils.py",
   shell: """
     wget -qO {output.taxdump_utils} https://raw.githubusercontent.com/dib-lab/2018-ncbi-lineages/63e8dc784af092293362f2e8e671ae03d1a84d1d/ncbi_taxdump_utils.py
-    chmod +x {output.taxdump_utils}
+    wget -qO {output.make_lineage_csv} https://raw.githubusercontent.com/dib-lab/2018-ncbi-lineages/63e8dc784af092293362f2e8e671ae03d1a84d1d/make-lineage-csv.py
+    chmod +x {output.make_lineage_csv}
   """
 
 rule lca_lineage_csv:

--- a/Snakefile.assembly
+++ b/Snakefile.assembly
@@ -37,7 +37,6 @@ rule sbt:
 rule lca:
   output:
     lca = "outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz",
-    report = "outputs/lca/reports/{db}-{domain}-k{ksize}-scaled10k.txt"
   input:
     lineage = "outputs/lca/lineages/{domain}_{db}_lineage.csv",
     catalog = "outputs/catalog/{domain}/{db}.txt",
@@ -51,7 +50,7 @@ rule lca:
     sourmash lca index \
       -k {params.ksize} \
       --scaled 10000 \
-      --report {output.report} \
+      --report outputs/lca/reports/{params.db}-{params.domain}-k{params.ksize}-scaled10k.txt \
       -f -C 3 --split-identifiers \
       --from-file <(tail +2 {input.catalog}) \
       {input.lineage} \
@@ -93,14 +92,15 @@ checkpoint catalog:
                   accession = row['assembly_accession']
                   path = f"{basedir}/{accession}.sig"
                   if not os.path.exists(path):
-                      # TODO: check if we can download and compute it
+                      # check if we can download and compute it
                       try:
                           url = url_for_accession(accession)
                       except ValueError:
                           # TODO: log this somehow
                           print(f"can't find URL for {accession}")
-                          # TODO: decide if an older version should be used
-                          #       logic needs to be implemented here
+
+                          # TODO: if we decide an older version should be used
+                          #       then logic needs to be implemented here
                           continue
 
                       # if URL is valid, let's calculate locally
@@ -135,9 +135,6 @@ def url_for_accession(accession):
     url = "https" + url[3:]
     return f"{url}/{full_name}/{full_name}_genomic.fna.gz"
 
-    # TODO: alternative is read assembly_summary for asm_name
-    #return f"{url}/{accession}_{asm_name}"
-
 
 def name_for_accession(domain, accession):
     import csv
@@ -164,12 +161,18 @@ def name_for_accession(domain, accession):
         raise ValueError("Accession not in this summary file!")
 
 
-# TODO: fix the input, need to calculate genbank/refseq from accession
+def choose_summary(w):
+    if w.accession.startswith("GCF"):
+        return f"outputs/assembly_stats/{w.domain}/assembly_summary_refseq.txt.gz",
+    elif w.accession.startswith("GCA"):
+        return f"outputs/assembly_stats/{w.domain}/assembly_summary_genbank.txt.gz",
+
+    raise ValueError(f"Couldn't decide assembly summary with {w.accession}")
+
+
 rule compute:
   output: "outputs/sigs/{domain}/{accession}.sig"
-  input:
-    genbank="outputs/assembly_stats/{domain}/assembly_summary_genbank.txt.gz",
-    refseq="outputs/assembly_stats/{domain}/assembly_summary_refseq.txt.gz",
+  input: choose_summary
   params:
     ksizes=lambda w: ",".join(str(k) for k in config["db_ksizes"]),
     scaled=1000,
@@ -186,6 +189,7 @@ rule compute:
 
 ## TODO: write rule to validate SBTs
 # - check that all sigs in catalog are in the SBT too
+# - maybe run some searches?
 
 ### Prepare LCA lineages
 

--- a/Snakefile.assembly
+++ b/Snakefile.assembly
@@ -3,11 +3,10 @@ import random
 
 configfile: "config.assembly.yml"
 
-# rule 'all' builds specific SBTs.
 rule all:
   input:
     expand("outputs/sbt/{db}-{domain}-x{bfsize}-k{ksize}.sbt.zip", db=config['db'], ksize=config['db_ksizes'], domain=config['domains'], bfsize=config['bfsize']),
-#    expand("outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz", db=config['db'], domain=config['domains'], ksize=config['db_ksizes'])
+    expand("outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz", db=config['db'], domain=config['domains'], ksize=config['db_ksizes'])
 
 
 def sigs_in_catalog(w):
@@ -29,28 +28,35 @@ rule sbt:
     sourmash index \
       -k {params.ksize} \
       -x {params.bfsize} \
-      --from-file <(tail +1 {input.catalog}) \
+      --from-file <(tail +2 {input.catalog}) \
       {output} $(head -1 {input.catalog})
     """
 
+
 rule lca:
-  output: "outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz",
+  output:
+    lca = "outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz",
+    report = "outputs/lca/reports/{db}-{domain}-k{ksize}-scaled10k.txt"
   input:
-    lineage="domain-{domain}.acc.lineages.csv"
+    lineage = "outputs/lca/lineages/{domain}_{db}_lineage.csv",
+    catalog = "outputs/catalog/{domain}/{db}.txt",
+    sigs = sigs_in_catalog
   params:
     ksize="{ksize}",
     db="{db}",
     domain="{domain}",
-    config="{config}"
   shell: """
     sourmash lca index \
       -k {params.ksize} \
       --scaled 10000 \
-      --report report-lca-{params.db}-{params.domain}-{params.ksize}.txt \
-      --traverse-directory -C 3 --split-identifiers \
-      domain-{params.domain}.acc.lineages.csv \
-      {output} outputs/sigs/{params.config}/{params.db}/{params.domain}
+      --report {output.report} \
+      -f -C 3 --split-identifiers \
+      --from-file <(tail +2 {input.catalog}) \
+      {input.lineage} \
+      {output.lca} $(head -1 {input.catalog})
   """
+
+## Rules for building signature catalogs for each index
 
 rule download_catalog:
   output:
@@ -85,8 +91,20 @@ checkpoint catalog:
                   accession = row['assembly_accession']
                   path = f"{basedir}/{accession}.sig"
                   if not os.path.exists(path):
-                      # let's calculate locally
+                      # TODO: check if we can download and compute it
+                      try:
+                          url = url_for_accession(accession)
+                      except ValueError:
+                          # TODO: log this somehow
+                          print(f"can't find URL for {accession}")
+                          # TODO: decide if an older version should be used
+                          #       logic needs to be implemented here
+                          continue
+
+                      # if URL is valid, let's calculate locally
                       path = f"outputs/sigs/{params.domain}/{accession}.sig"
+
+                  # either sig exists in sig_store, or can be computed
                   fout.write(path + '\n')
 
 
@@ -98,11 +116,16 @@ def url_for_accession(accession):
     number = "/".join([number[pos:pos + 3] for pos in range(0, len(number), 3)])
     url = f"ftp://ftp.ncbi.nlm.nih.gov/genomes/all/{db}/{number}"
 
-    all_names = shell(f"curl -l {url}/", read=True).split('\n')
+    from subprocess import CalledProcessError
+    try:
+        all_names = shell(f"curl -s -l {url}/", read=True).split('\n')
+    except CalledProcessError as e:
+        # TODO: might check here if it was a 404 or 5xx, assuming 404
+        raise ValueError(f"Can't find URL for {accession}, tried {url}")
 
     full_name = None
     for name in all_names:
-        db_, acc_, _ = name.split("_")
+        db_, acc_, *_ = name.split("_")
         if db_ == db and acc == acc_:
             full_name = name
             break
@@ -156,5 +179,42 @@ rule compute:
       --track-abundance \
       --name {params.name:q} \
       -o {output} \
-      <(curl {params.url_path} | zcat)
+      <(curl -s {params.url_path} | zcat)
+  """
+
+## TODO: write rule to validate SBTs
+# - check that all sigs in catalog are in the SBT too
+
+### Prepare LCA lineages
+
+rule download_lca_scripts:
+  output:
+    make_lineage_csv = "scripts/make-lineage-csv.py",
+    taxdump_utils = "scripts/ncbi_taxdump_utils.py",
+  shell: """
+    wget -qO {output.taxdump_utils} https://raw.githubusercontent.com/dib-lab/2018-ncbi-lineages/63e8dc784af092293362f2e8e671ae03d1a84d1d/ncbi_taxdump_utils.py
+    chmod +x {output.taxdump_utils}
+  """
+
+rule lca_lineage_csv:
+  output: "outputs/lca/lineages/{domain}_{db}_lineage.csv",
+  input:
+    summary = "outputs/assembly_stats/{domain}/assembly_summary_{db}.txt.gz",
+    make_acc_taxid_mapping = "scripts/make-acc-taxid-mapping.py",
+    make_lineage_csv = "scripts/make-lineage-csv.py",
+    taxonomy = expand("outputs/taxonomy/{file}.dmp", file=('nodes', 'names')),
+  shell: """
+    {input.make_lineage_csv} {input.taxonomy} <({input.make_acc_taxid_mapping} {input.summary}) -o {output}
+  """
+
+rule download_taxonomy:
+  output:
+    names = 'outputs/taxonomy/names.dmp',
+    nodes = 'outputs/taxonomy/nodes.dmp',
+    generated="outputs/taxonomy/timestamp",
+  shell: """
+    (cd outputs/taxonomy && \
+    wget https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz && \
+    tar xf taxdump.tar.gz)
+    date +%Y%m%d > {output.generated}
   """

--- a/Snakefile.assembly
+++ b/Snakefile.assembly
@@ -1,0 +1,82 @@
+import os.path
+import random
+
+configfile: "config.assembly.yml"
+
+# load in list of genomes by domain
+DOMAINS=config['domains']
+
+###
+
+# rule 'all' builds specific SBTs.
+rule all:
+  input:
+    expand("outputs/sbt/{db}-{domain}-x{bfsize}-k{ksize}.sbt.zip", db=config['db'], ksize=config['db_ksizes'], domain=config['domains'], bfsize=config['bfsize']),
+#    expand("outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz", db=config['db'], domain=config['domains'], ksize=config['db_ksizes'])
+
+rule sbt:
+  output: "outputs/{index}/{db}-{domain}-x{bfsize}-k{ksize}.sbt.zip"
+  input:
+    catalog = "outputs/catalog/{domain}/{db}.txt"
+  params:
+    ksize="{ksize}",
+    db="{db}",
+    domain="{domain}",
+    bfsize="{bfsize}",
+  shell: """
+    sourmash index \
+      -k {params.ksize} \
+      -x {params.bfsize} \
+      --from-file <(tail +1 {input.catalog}) \
+      {output} $(head -1 {input.catalog})
+    """
+
+rule lca:
+  output: "outputs/lca/{db}-{domain}-k{ksize}-scaled10k.lca.json.gz",
+  input:
+    lineage="domain-{domain}.acc.lineages.csv"
+  params:
+    ksize="{ksize}",
+    db="{db}",
+    domain="{domain}",
+    config="{config}"
+  shell: """
+    sourmash lca index \
+      -k {params.ksize} \
+      --scaled 10000 \
+      --report report-lca-{params.db}-{params.domain}-{params.ksize}.txt \
+      --traverse-directory -C 3 --split-identifiers \
+      domain-{params.domain}.acc.lineages.csv \
+      {output} outputs/sigs/{params.config}/{params.db}/{params.domain}
+  """
+
+rule download_catalog:
+  output:
+    catalog="outputs/assembly_stats/{domain}/assembly_summary_{db}.txt.gz",
+    generated="outputs/assembly_stats/{domain}/assembly_summary_{db}.timestamp",
+  params:
+    domain="{domain}",
+    db="{db}"
+  shell: """
+    wget --header='Accept-Encoding: gzip' -O {output.catalog} https://ftp.ncbi.nlm.nih.gov/genomes/{params.db}/{params.domain}/assembly_summary.txt
+    date +%Y%m%d > {output.generated}
+  """
+
+rule catalog:
+  output: "outputs/catalog/{domain}/{db}.txt"
+  input: "outputs/assembly_stats/{domain}/assembly_summary_{db}.txt.gz"
+  run:
+      import csv
+      import gzip
+
+      basedir = config['sig_location']
+
+      with gzip.open(input[0], 'rt') as fp:
+          fp.readline() # skip first line
+          fp.read(2) # skip initial comment in header
+          data = csv.DictReader(fp, delimiter='\t')
+
+          with open(output[0], 'w') as fout:
+              for row in data:
+                  accession = row['assembly_accession']
+                  fout.write(f"{basedir}/{accession}.sig\n")

--- a/Snakefile.assembly
+++ b/Snakefile.assembly
@@ -15,7 +15,7 @@ def sigs_in_catalog(w):
 
 
 rule sbt:
-  output: "outputs/{index}/{db}-{domain}-x{bfsize}-k{ksize}.sbt.zip"
+  output: "outputs/sbt/{db}-{domain}-x{bfsize}-k{ksize}.sbt.zip"
   input:
     catalog = "outputs/catalog/{domain}/{db}.txt",
     sigs = sigs_in_catalog
@@ -24,6 +24,7 @@ rule sbt:
     db="{db}",
     domain="{domain}",
     bfsize="{bfsize}",
+  benchmark: "benchmark/sbt/{db}-{domain}-x{bfsize}-k{ksize}.txt"
   shell: """
     sourmash index \
       -k {params.ksize} \
@@ -45,6 +46,7 @@ rule lca:
     ksize="{ksize}",
     db="{db}",
     domain="{domain}",
+  benchmark: "benchmark/lca/{db}-{domain}-k{ksize}.txt"
   shell: """
     sourmash lca index \
       -k {params.ksize} \

--- a/config.assembly.yml
+++ b/config.assembly.yml
@@ -12,8 +12,8 @@ domains:
 #- metagenomes
 #- other
 
-# top level directory precomputed signatures
-sig_location: /data/wort/wort-genomes/sigs
+# top level directory for precomputed signatures
+sig_store: /data/wort/wort-genomes/sigs
 
 # ksizes to build the databases for
 db_ksizes:
@@ -24,10 +24,10 @@ db_ksizes:
 # options: genbank, refseq
 db:
 - refseq
-#- genbank
+- genbank
 
 # bloom filter sizes for SBTs
 bfsize:
-- 1e4
-- 1e5
 - 1e6
+#- 1e5
+#- 1e4

--- a/config.assembly.yml
+++ b/config.assembly.yml
@@ -1,7 +1,7 @@
 domains:
 - fungi
 - archaea
-#- bacteria
+- bacteria
 - viral
 #- invertebrate
 #- plant
@@ -9,8 +9,9 @@ domains:
 #- vertebrate_mammalian
 #- vertebrate_other
 ## only for genbank
-#- metagenomes
 #- other
+## does it even make sense to make an SBT of the genbank metagenomes?
+#- metagenomes
 
 # top level directory for precomputed signatures
 sig_store: /data/wort/wort-genomes/sigs
@@ -29,5 +30,5 @@ db:
 # bloom filter sizes for SBTs
 bfsize:
 - 1e6
-#- 1e5
-#- 1e4
+- 1e5
+- 1e4

--- a/config.assembly.yml
+++ b/config.assembly.yml
@@ -1,0 +1,33 @@
+domains:
+- fungi
+- archaea
+#- bacteria
+- viral
+#- invertebrate
+#- plant
+- protozoa
+#- vertebrate_mammalian
+#- vertebrate_other
+## only for genbank
+#- metagenomes
+#- other
+
+# top level directory precomputed signatures
+sig_location: /data/wort/wort-genomes/sigs
+
+# ksizes to build the databases for
+db_ksizes:
+- 21
+- 31
+- 51
+
+# options: genbank, refseq
+db:
+- refseq
+#- genbank
+
+# bloom filter sizes for SBTs
+bfsize:
+- 1e4
+- 1e5
+- 1e6

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - python=3.7
   - snakemake-minimal=5.20.1
   - sourmash-minimal>=3.4,<4
+  - curl

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: sourmash_databases
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=3.7
+  - snakemake-minimal=5.20.1
+  - sourmash-minimal>=3.4,<4

--- a/scripts/make-acc-taxid-mapping.py
+++ b/scripts/make-acc-taxid-mapping.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python
+"""
+Take an NCBI 'assembly_summary.txt' file and print to
+stdout the accessions and their associated taxids.
+"""
+
+import argparse
+import csv
+import gzip
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('summary')
+    args = p.parse_args()
+
+    with gzip.open(args.summary, 'rt') as fp:
+        fp.readline() # skip first line
+        fp.read(2) # skip initial comment in header
+        data = csv.DictReader(fp, delimiter='\t')
+        for row in data:
+            # --split-identifiers in `sourmash lca index` doesn't behave
+            # well with version, so remove it
+            accession = row['assembly_accession'].split('.')[0]
+            taxid = row['taxid']
+            print(f'{accession},{taxid}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/make-acc-taxid-mapping.py
+++ b/scripts/make-acc-taxid-mapping.py
@@ -11,6 +11,7 @@ import gzip
 
 def main():
     p = argparse.ArgumentParser()
+    p.add_argument('--strip-version', action='store_true')
     p.add_argument('summary')
     args = p.parse_args()
 
@@ -19,9 +20,11 @@ def main():
         fp.read(2) # skip initial comment in header
         data = csv.DictReader(fp, delimiter='\t')
         for row in data:
-            # --split-identifiers in `sourmash lca index` doesn't behave
-            # well with version, so remove it
-            accession = row['assembly_accession'].split('.')[0]
+            accession = row['assembly_accession']
+            if args.strip_version:
+                # --split-identifiers in `sourmash lca index` doesn't behave
+                # well with version, so remove it
+                accession = accession.split('.')[0]
             taxid = row['taxid']
             print(f'{accession},{taxid}')
 


### PR DESCRIPTION
Fixes #7 

- Using signatures calculated with `wort`. If the signature is not available, fall back to calculate it by figuring out the download URL and streaming the data.
- The `assembly_summary.txt` is downloaded for each GenBank/RefSeq domain, and used to create a catalog, a file with paths to where signatures for each accession are located.
- SBT and LCA index rules read catalog with `--from-file`, currently using a weird syntax to extract the first signature and pass to index (and pass the others with `--from-file`) because `index` requires one signature...

## TODO

- [x] generate a `taxid4index` file...
- [ ] and add to `.sbt.zip` (so I can use it with [gather-to-opal](https://github.com/dib-lab/2019-12-12-sourmash_viz/blob/1223b736add63ea49108eecceb3f4bca85c78492/src/gather_to_opal.py))
- [x] add back `compute` rule
- [x] probably use a `checkpoint` to calculate missing signatures from the `sig_collection` dir?
- [x] LCA index rule
- [x] generate lineages (need to download NCBI taxonomy too)
- [x] decide about skipping or using older version of assembly if current data is missing