### PR TITLE
sketch,build sbts w sourmash 4.0, multiple alphabets

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -1,29 +1,31 @@
 output_dir: gtdb-databases
 basename: gtdb-r95
 
+dna_input: True
+protein_input: False
 # defaults for each alphabet 
 alphabet_defaults:
   nucleotide: 
     ksizes: [21,31,51]
-    scaled: 2000
+    scaled: [2000]
     alpha_cmd: "--dna"
     moltype: "dna"
     ksize_multiplier: 1
   protein:
     ksizes: [11]
-    scaled: 100
+    scaled: [100]
     alpha_cmd: "--protein"
     moltype: "protein"
     ksize_multiplier: 3
   dayhoff:
     ksizes: [19]
-    scaled: 100
+    scaled: [100]
     alpha_cmd: "--dayhoff"
     moltype: "dayhoff"
     ksize_multiplier: 3
   hp:
     ksizes: [33]
-    scaled: 100
+    scaled: [100]
     alpha_cmd: "--hp"
     moltype: "hp"
     ksize_multiplier: 3

--- a/defaults.yml
+++ b/defaults.yml
@@ -1,0 +1,29 @@
+output_dir: gtdb-databases
+basename: gtdb-r95
+
+# defaults for each alphabet 
+alphabet_defaults:
+  nucleotide: 
+    ksizes: [21,31,51]
+    scaled: 2000
+    alpha_cmd: "--dna"
+    moltype: "dna"
+    ksize_multiplier: 1
+  protein:
+    ksizes: [11]
+    scaled: 100
+    alpha_cmd: "--protein"
+    moltype: "protein"
+    ksize_multiplier: 3
+  dayhoff:
+    ksizes: [19]
+    scaled: 100
+    alpha_cmd: "--dayhoff"
+    moltype: "dayhoff"
+    ksize_multiplier: 3
+  hp:
+    ksizes: [33]
+    scaled: 100
+    alpha_cmd: "--hp"
+    moltype: "hp"
+    ksize_multiplier: 3

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: sourmash_databases
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=3.8
+  - snakemake=5.26.1
+  - pandas=1.1.3

--- a/envs/sourmash-dev.yml
+++ b/envs/sourmash-dev.yml
@@ -1,0 +1,12 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python>=3.7
+  - pytest
+  - rust
+  - pip
+  - pip:
+    - git+https://github.com/dib-lab/sourmash@latest
+    - dendropy==4.4.0

--- a/farm-build-sbts.sh
+++ b/farm-build-sbts.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -login
+#SBATCH -p bmh
+#SBATCH -J sbt-gtdb
+#SBATCH --mail-type=ALL
+#SBATCH --mail-user=ntpierce@ucdavis.edu
+#SBATCH -t 3-0:00:00
+#SBATCH -N 1
+#SBATCH -n 1
+#SBATCH -c 1
+#SBATCH --chdir /group/ctbrowngrp/sourmash_databases
+#SBATCH --mem=10gb
+
+# build sbts
+
+# activate conda in general
+. "/home/ntpierce/miniconda3/etc/profile.d/conda.sh"
+
+conda activate sourmash_databases
+
+set -o nounset
+set -o errexit
+set -x
+
+snakemake -s index-from-csv.snakefile -j 10 --resources mem_mb=300000 --profile farm_utils/slurm_profile --cluster-config cluster_config.yml
+
+#echo ${SLURM_JOB_NODELIST}       # Output Contents of the SLURM NODELIST
+
+env | grep SLURM            # Print out values of the current jobs SLURM environment variables
+
+scontrol show job ${SLURM_JOB_ID}     # Print out final statistics about resource uses before job exits
+
+#sstat --format 'JobID,MaxRSS,AveCPU' -P ${SLURM_JOB_ID}.batch

--- a/farm-build-sigs.sh
+++ b/farm-build-sigs.sh
@@ -3,7 +3,7 @@
 #SBATCH -J sigs-gtdb
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=ntpierce@ucdavis.edu
-#SBATCH --chdir /group/ctbrowngrp/sourmash_databases
+#SBATCH --chdir /home/ntpierce/sourmash_databases
 #SBATCH -t 3-0:00:00
 #SBATCH -N 1
 #SBATCH -n 1

--- a/farm-build-sigs.sh
+++ b/farm-build-sigs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -login
+#SBATCH -p bmm
+#SBATCH -J sigs-gtdb
+#SBATCH --mail-type=ALL
+#SBATCH --mail-user=ntpierce@ucdavis.edu
+#SBATCH --chdir /group/ctbrowngrp/sourmash_databases
+#SBATCH -t 3-0:00:00
+#SBATCH -N 1
+#SBATCH -n 1
+#SBATCH -c 32
+#SBATCH --mem=10gb
+
+# generate sigs
+
+# activate conda in general
+. "/home/ntpierce/miniconda3/etc/profile.d/conda.sh"
+
+conda activate sourmash_databases
+
+set -o nounset
+set -o errexit
+set -x
+
+snakemake -s index-from-csv.snakefile -j 32 --until signames_to_file --profile farm_utils/default_profile
+
+#echo ${SLURM_JOB_NODELIST}       # Output Contents of the SLURM NODELIST
+
+env | grep SLURM            # Print out values of the current jobs SLURM environment variables
+
+scontrol show job ${SLURM_JOB_ID}     # Print out final statistics about resource uses before job exits
+
+#sstat --format 'JobID,MaxRSS,AveCPU' -P ${SLURM_JOB_ID}.batch

--- a/farm-index.sh
+++ b/farm-index.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -login
 #SBATCH -p bmh
-#SBATCH -J sbt-gtdb
+#SBATCH -J index-gtdb
 #SBATCH --mail-type=ALL
 #SBATCH --mail-user=ntpierce@ucdavis.edu
 #SBATCH -t 3-0:00:00
 #SBATCH -N 1
 #SBATCH -n 1
 #SBATCH -c 1
-#SBATCH --chdir /group/ctbrowngrp/sourmash_databases
+#SBATCH --chdir /home/ntpierce/sourmash_databases
 #SBATCH --mem=10gb
 
 # build sbts
@@ -21,7 +21,7 @@ set -o nounset
 set -o errexit
 set -x
 
-snakemake -s index-from-csv.snakefile -j 10 --resources mem_mb=300000 --profile farm_utils/slurm_profile --cluster-config cluster_config.yml
+snakemake -s index-from-csv.snakefile -j 10 --resources mem_mb=300000 --profile farm_utils/slurm_profile --cluster-config farm_utils/cluster_config.yml
 
 #echo ${SLURM_JOB_NODELIST}       # Output Contents of the SLURM NODELIST
 

--- a/index-from-csv.snakefile
+++ b/index-from-csv.snakefile
@@ -132,6 +132,7 @@ rule sourmash_sketch_nucleotide_input:
     params:
         sketch_params = build_sketch_params("nucleotide"),
         signame_cmd = lambda w: build_signame_cmd(w.sample, "nucleotide"),
+        singleton_cmd = " --singleton " if singleton else ""
     threads: 1
     resources:
         mem_mb=lambda wildcards, attempt: attempt *1000,
@@ -142,7 +143,7 @@ rule sourmash_sketch_nucleotide_input:
     conda: "envs/sourmash-dev.yml"
     shell:
         """
-        sourmash sketch dna -p {params.sketch_params} -o {output} {params.signame_cmd} {input}  2> {log}
+        sourmash sketch dna -p {params.sketch_params} -o {output} {params.signame_cmd} {params.singleton_cmd} {input}  2> {log}
         """
     
 if protein_input:
@@ -153,6 +154,7 @@ if protein_input:
         params:
             sketch_params = build_sketch_params("protein"),
             signame_cmd = lambda w: build_signame_cmd(w.sample, "protein"),
+            singleton_cmd = " --singleton " if singleton else ""
         threads: 1
         resources:
             mem_mb=lambda wildcards, attempt: attempt *1000,
@@ -163,7 +165,7 @@ if protein_input:
         conda: "envs/sourmash-dev.yml"
         shell:
             """
-            sourmash sketch protein {params.sketch_params} -o {output} {params.signame_cmd} {input} 2> {log}
+            sourmash sketch protein {params.sketch_params} -o {output} {params.signame_cmd} {params.singleton_cmd} {input} 2> {log}
             """
 
 localrules: signames_to_file

--- a/index-from-csv.snakefile
+++ b/index-from-csv.snakefile
@@ -119,10 +119,10 @@ def build_signame_cmd(sample, input_type):
             signame = genome_info.at[sample, 'signame']
         elif input_type == "protein":
             sgname = protein_info.at[sample, 'signame'],
-        signame_cmd =  f" --name {signame:q}"
+        signame_cmd =  f" --name {signame:q} "
         return signame_cmd
     else:
-        return ""
+        return " --singleton "
 
 rule sourmash_sketch_nucleotide_input:
     input: 
@@ -132,7 +132,6 @@ rule sourmash_sketch_nucleotide_input:
     params:
         sketch_params = build_sketch_params("nucleotide"),
         signame_cmd = lambda w: build_signame_cmd(w.sample, "nucleotide"),
-        singleton_cmd = " --singleton " if singleton else ""
     threads: 1
     resources:
         mem_mb=lambda wildcards, attempt: attempt *1000,
@@ -143,7 +142,7 @@ rule sourmash_sketch_nucleotide_input:
     conda: "envs/sourmash-dev.yml"
     shell:
         """
-        sourmash sketch dna -p {params.sketch_params} -o {output} {params.signame_cmd} {params.singleton_cmd} {input}  2> {log}
+        sourmash sketch dna -p {params.sketch_params} {params.signame_cmd} -o {output} {input}  2> {log}
         """
     
 if protein_input:
@@ -165,7 +164,7 @@ if protein_input:
         conda: "envs/sourmash-dev.yml"
         shell:
             """
-            sourmash sketch protein {params.sketch_params} -o {output} {params.signame_cmd} {params.singleton_cmd} {input} 2> {log}
+            sourmash sketch protein {params.sketch_params} {params.signame_cmd} -o {output} {input} 2> {log}
             """
 
 localrules: signames_to_file

--- a/index-from-csv.snakefile
+++ b/index-from-csv.snakefile
@@ -3,7 +3,7 @@ import pandas as pd
 import glob
 
 configfile: "defaults.yml"
-configfile: "index_config.yml"
+#configfile: "index_config.yml" # original gtdb config
 
 out_dir = config["output_dir"]
 logs_dir = os.path.join(out_dir, "logs")
@@ -20,6 +20,7 @@ def sanitize_path(path):
 ## this file must have at least two columns: accession,filename
 def read_samples(samples_file, data_dir):
     samples = pd.read_csv(samples_file, dtype=str, sep=",", header=0)
+    samples["accession"] = samples["accession"].str.split(" ", expand=True)[0]
     if "signame" not in samples.columns:
         if "species" in samples.columns:
             samples['signame'] = samples["accession"] + " " + samples["species"]
@@ -36,12 +37,25 @@ def read_samples(samples_file, data_dir):
             print(f'** ERROR: genome file {filename} does not exist in {data_dir}')
     return samples
 
-genome_info = read_samples(config["genomes_csv"], data_dir)
-sample_names = genome_info.index.tolist()
-if config.get("proteins_csv"):
+# figure out inputs
+dna_input = config.get("dna_input", True)
+protein_input = config.get("protein_input", False)
+singleton = config.get("singleton", False)
+alphabet_info = config["alphabet_info"]
+sample_names = []
+input_types=[]
+
+if dna_input:
+    genome_info = read_samples(config["genomes_csv"], data_dir)
+    sample_names = genome_info.index.tolist()
+    input_types +=["dna-input"]
+if protein_input:
     protein_info = read_samples(config["proteins_csv"], data_dir)
+    input_types +=["protein-input"]
+    if not sample_names:
+        sample_names = protein_info.index.tolist()
 elif any(alpha in ["protein", "dayhoff", "hp"] for alpha in alphabet_info):
-    print("Error: protein alphabets found in the desired sbt alphabets. Please provide a csv with protein input.")
+    print("Error: protein alphabets found in the desired sbt alphabets. Please set 'protein_input: True' in your config and provide a csv with protein input ('proteins_csv').")
     sys.exit(-1)
 
 onstart:
@@ -55,7 +69,6 @@ onsuccess:
 onerror:
     print("Alas!\n")
 
-alphabet_info = config["alphabet_info"]
 index_info= []
 
 wildcard_constraints:
@@ -66,13 +79,16 @@ for alphabet, info in alphabet_info.items():
     aks = expand("{alpha}-k{ksize}-scaled{scaled}", alpha=alphabet, ksize=info["ksizes"], scaled=info["scaled"])
     index_info.extend(aks)
 
+index_types = ["sbt.zip"]
+make_lca = config.get("index_lca", False)
+if make_lca:
+    index_types.append("lca.json.gz")
+
 
 rule all:
     input: 
-        expand(os.path.join(out_dir, "dna-input", "{basename}.signatures.txt"), basename=basename),
-        expand(os.path.join(out_dir, "protein-input", "{basename}.signatures.txt"), basename=basename),
-        expand(os.path.join(out_dir, "index", "{basename}.{idx_info}.sbt.zip"), basename=basename, idx_info=index_info),
-        expand(os.path.join(out_dir, "index", "{basename}.{idx_info}.lca.json.gz"), basename=basename, idx_info=index_info),
+        expand(os.path.join(out_dir, "{input_type}", "{basename}.signatures.txt"), basename=basename, input_type = input_types),
+        expand(os.path.join(out_dir, "index", "{basename}.{idx_info}.{idx_type}"), basename=basename, idx_info=index_info, idx_type=index_types),
 
 
 ## sketching rules ##
@@ -80,7 +96,8 @@ def build_sketch_params(output_type):
     sketch_cmd = ""
     if output_type == "nucleotide":
         ksizes = config["alphabet_info"]["nucleotide"].get("ksizes", config["alphabet_defaults"]["nucleotide"]["ksizes"])
-        scaled = config["alphabet_info"]["nucleotide"].get("scaled", config["alphabet_defaults"]["nucleotide"]["scaled"])
+        # just build signatures at the highest resolution (lowest scaled value). Index can downsample for us.
+        scaled = min(config["alphabet_info"]["nucleotide"].get("scaled", config["alphabet_defaults"]["nucleotide"]["scaled"]))
         # maybe don't track abundance?
         sketch_cmd = "k=" + ",k=".join(map(str, ksizes)) + f",scaled={str(scaled)}" + ",abund"
         return sketch_cmd
@@ -96,6 +113,17 @@ def build_sketch_params(output_type):
             sketch_cmd += " -p " + alpha + ",k=" + ",k=".join(map(str, ksizes)) + f",scaled={str(scaled)}" + ",abund"
     return sketch_cmd
 
+def build_signame_cmd(sample, input_type):
+    if not singleton:
+        if input_type == "nucleotide":
+            signame = genome_info.at[sample, 'signame']
+        elif input_type == "protein":
+            sgname = protein_info.at[sample, 'signame'],
+        signame_cmd =  f" --name {signame:q}"
+        return signame_cmd
+    else:
+        return ""
+
 rule sourmash_sketch_nucleotide_input:
     input: 
         lambda w: os.path.join(data_dir, genome_info.at[w.sample, 'filename'])
@@ -103,7 +131,7 @@ rule sourmash_sketch_nucleotide_input:
         os.path.join(out_dir, "dna-input", "signatures", "{sample}.sig"),
     params:
         sketch_params = build_sketch_params("nucleotide"),
-        signame = lambda w: genome_info.at[w.sample, 'signame'],
+        signame_cmd = lambda w: build_signame_cmd(w.sample, "nucleotide"),
     threads: 1
     resources:
         mem_mb=lambda wildcards, attempt: attempt *1000,
@@ -114,32 +142,33 @@ rule sourmash_sketch_nucleotide_input:
     conda: "envs/sourmash-dev.yml"
     shell:
         """
-        sourmash sketch dna -p {params.sketch_params} -o {output} --name {params.signame:q} {input}  2> {log}
+        sourmash sketch dna -p {params.sketch_params} -o {output} {params.signame_cmd} {input}  2> {log}
         """
     
-rule sourmash_sketch_protein_input:
-    input: lambda w: os.path.join(data_dir, protein_info.at[w.sample, 'filename'])
-    output:
-        os.path.join(out_dir, "protein-input", "signatures", "{sample}.sig"),
-    params:
-        sketch_params = build_sketch_params("protein"),
-        signame = lambda w: protein_info.at[w.sample, 'signame'],
-    threads: 1
-    resources:
-        mem_mb=lambda wildcards, attempt: attempt *1000,
-        runtime=1200,
-    group: "sigs"
-    log: os.path. join(logs_dir, "sourmash_sketch_prot_input", "{sample}.sketch.log")
-    benchmark: os.path.join(benchmarks_dir, "sourmash_sketch_prot_input", "{sample}.sketch.benchmark")
-    conda: "envs/sourmash-dev.yml"
-    shell:
-        """
-        sourmash sketch protein {params.sketch_params} -o {output} --name {params.signame:q} {input} 2> {log}
-        """
+if protein_input:
+    rule sourmash_sketch_protein_input:
+        input: lambda w: os.path.join(data_dir, protein_info.at[w.sample, 'filename'])
+        output:
+            os.path.join(out_dir, "protein-input", "signatures", "{sample}.sig"),
+        params:
+            sketch_params = build_sketch_params("protein"),
+            signame_cmd = lambda w: build_signame_cmd(w.sample, "protein"),
+        threads: 1
+        resources:
+            mem_mb=lambda wildcards, attempt: attempt *1000,
+            runtime=1200,
+        group: "sigs"
+        log: os.path. join(logs_dir, "sourmash_sketch_prot_input", "{sample}.sketch.log")
+        benchmark: os.path.join(benchmarks_dir, "sourmash_sketch_prot_input", "{sample}.sketch.benchmark")
+        conda: "envs/sourmash-dev.yml"
+        shell:
+            """
+            sourmash sketch protein {params.sketch_params} -o {output} {params.signame_cmd} {input} 2> {log}
+            """
 
 localrules: signames_to_file
 
-rule signames_to_file:
+checkpoint signames_to_file:
     input:  expand(os.path.join(out_dir, "{{input_type}}", "signatures", "{sample}.sig"), sample=sample_names),
     output: os.path.join(out_dir, "{input_type}", "{basename}.signatures.txt")
     group: "sigs"
@@ -176,10 +205,16 @@ rule index_sbt:
         --from-file {input}  2> {log}
         """
 
+def get_lineages(w):
+    if w.alphabet in ["protein", "dayhoff", "hp"]:
+        return config["proteins_csv"]
+    else:
+        return config["genomes_csv"]
+
 rule index_lca:
     input:
         sigfile=get_siglist,
-        lineages= config["genomes_csv"]
+        lineages=get_lineages
     output: os.path.join(out_dir, "index", "{basename}.{alphabet}-k{ksize}-scaled{scaled}.lca.json.gz"),
     threads: 1
     params:
@@ -196,7 +231,6 @@ rule index_lca:
         """
         sourmash lca index --ksize {params.ksize} \
           --scaled {wildcards.scaled} --from-file {input.sigfile} \
-          --split-identifiers --start-column 4 \
-          --require-taxonomy --report {params.report} \
+          --start-column 3 --require-taxonomy --report {params.report} \
           {params.alpha_cmd} {input.lineages} {output} 2> {log} \
         """

--- a/index-from-csv.snakefile
+++ b/index-from-csv.snakefile
@@ -1,0 +1,176 @@
+import os, sys
+import pandas as pd
+import glob
+
+configfile: "defaults.yml"
+configfile: "index_config.yml"
+
+out_dir = config["output_dir"]
+logs_dir = os.path.join(out_dir, "logs")
+benchmarks_dir = os.path.join(out_dir, "benchmarks")
+data_dir = config['data_dir'].rstrip('/')
+basename = config["basename"]
+
+def sanitize_path(path):
+    # expand `~`, get absolute path
+    path = os.path.expanduser(path)
+    path = os.path.abspath(path)
+    return path
+
+## this file must have at least two columns: accession,filename
+def read_samples(samples_file, data_dir):
+    samples = pd.read_csv(samples_file, dtype=str, sep=",", header=0)
+    if "signame" not in samples.columns:
+        if "species" in samples.columns:
+            samples['signame'] = samples["accession"] + " " + samples["species"]
+        else:
+            samples['signame'] = samples["accession"]
+    samples.set_index("accession", inplace=True)
+    
+    # Now, verify that all genome files exist
+    data_dir = sanitize_path(data_dir)
+    sample_list = samples["filename"].tolist()
+    for filename in sample_list:
+        fullpath = os.path.join(data_dir, filename)
+        if not os.path.exists(fullpath):
+            print(f'** ERROR: genome file {filename} does not exist in {data_dir}')
+    return samples
+
+genome_info = read_samples(config["genomes_csv"], data_dir)
+sample_names = genome_info.index.tolist()
+if config.get("proteins_csv"):
+    protein_info = read_samples(config["proteins_csv"], data_dir)
+elif any(alpha in ["protein", "dayhoff", "hp"] for alpha in alphabet_info):
+    print("Error: protein alphabets found in the desired sbt alphabets. Please provide a csv with protein input.")
+    sys.exit(-1)
+
+onstart:
+    print("------------------------------")
+    print("    Build SBTs from csv")
+    print("------------------------------")
+
+onsuccess:
+    print("\n--- Workflow executed successfully! ---\n")
+
+onerror:
+    print("Alas!\n")
+
+alphabet_info = config["alphabet_info"]
+sbt_info= []
+
+wildcard_constraints:
+    alphabet="\w+",
+    ksize="\d+"
+
+for alphabet, info in alphabet_info.items():
+    aks = expand("{alpha}-k{ksize}-scaled{scaled}", alpha=alphabet, ksize=info["ksizes"], scaled=info["scaled"])
+    sbt_info.extend(aks)
+
+
+rule all:
+    input: 
+        expand(os.path.join(out_dir, "dna-input", "{basename}.signatures.txt"), basename=basename),
+        expand(os.path.join(out_dir, "protein-input", "{basename}.signatures.txt"), basename=basename),
+        expand(os.path.join(out_dir, "index", "{basename}.{sbtinfo}.sbt.zip"), basename=basename, sbtinfo=sbt_info),
+
+
+## sketching rules ##
+def build_sketch_params(output_type):
+    sketch_cmd = ""
+    if output_type == "nucleotide":
+        ksizes = config["alphabet_info"]["nucleotide"].get("ksizes", config["alphabet_defaults"]["nucleotide"]["ksizes"])
+        scaled = config["alphabet_info"]["nucleotide"].get("scaled", config["alphabet_defaults"]["nucleotide"]["scaled"])
+        # maybe don't track abundance?
+        sketch_cmd = "k=" + ",k=".join(map(str, ksizes)) + f",scaled={str(scaled)}" + ",abund"
+        return sketch_cmd
+    elif output_type == "protein":
+        for alpha in ["protein", "dayhoff", "hp"]:
+            if alpha in config["alphabet_info"].keys():
+                ## if ksizes aren't given, sketch protein, dayhoff, hp at the ksizes from default config
+                ksizes = config["alphabet_info"][alpha].get("ksizes", config["alphabet_defaults"][alpha]["ksizes"])
+                scaled = config["alphabet_info"][alpha].get("scaled", config["alphabet_defaults"][alpha]["scaled"])
+            else:
+                ksizes = config["alphabet_defaults"][alpha]["ksizes"]
+                scaled = config["alphabet_defaults"][alpha]["scaled"]
+            sketch_cmd += " -p " + alpha + ",k=" + ",k=".join(map(str, ksizes)) + f",scaled={str(scaled)}" + ",abund"
+    return sketch_cmd
+
+rule sourmash_sketch_nucleotide_input:
+    input: 
+        lambda w: os.path.join(data_dir, genome_info.at[w.sample, 'filename'])
+    output:
+        os.path.join(out_dir, "dna-input", "signatures", "{sample}.sig"),
+    params:
+        sketch_params = build_sketch_params("nucleotide"),
+        signame = lambda w: genome_info.at[w.sample, 'signame'],
+    threads: 1
+    resources:
+        mem_mb=lambda wildcards, attempt: attempt *1000,
+        runtime=1200,
+    group: "sigs"
+    log: os.path.join(logs_dir, "sourmash_sketch_nucl_input", "{sample}.sketch.log")
+    benchmark: os.path.join(benchmarks_dir, "sourmash_sketch_nucl_input", "{sample}.sketch.benchmark")
+    conda: "envs/sourmash-dev.yml"
+    shell:
+        """
+        sourmash sketch dna -p {params.sketch_params} -o {output} --name {params.signame:q} {input}  2> {log}
+        """
+    
+rule sourmash_sketch_protein_input:
+    input: lambda w: os.path.join(data_dir, protein_info.at[w.sample, 'filename'])
+    output:
+        os.path.join(out_dir, "protein-input", "signatures", "{sample}.sig"),
+    params:
+        sketch_params = build_sketch_params("protein"),
+        signame = lambda w: protein_info.at[w.sample, 'signame'],
+    threads: 1
+    resources:
+        mem_mb=lambda wildcards, attempt: attempt *1000,
+        runtime=1200,
+    group: "sigs"
+    log: os.path. join(logs_dir, "sourmash_sketch_prot_input", "{sample}.sketch.log")
+    benchmark: os.path.join(benchmarks_dir, "sourmash_sketch_prot_input", "{sample}.sketch.benchmark")
+    conda: "envs/sourmash-dev.yml"
+    shell:
+        """
+        sourmash sketch protein {params.sketch_params} -o {output} --name {params.signame:q} {input} 2> {log}
+        """
+
+localrules: signames_to_file
+
+rule signames_to_file:
+    input:  expand(os.path.join(out_dir, "{{input_type}}", "signatures", "{sample}.sig"), sample=sample_names),
+    output: os.path.join(out_dir, "{input_type}", "{basename}.signatures.txt")
+    group: "sigs"
+    run:
+        with open(str(output), "w") as outF:
+            for inF in input:
+                outF.write(str(inF) + "\n")
+
+
+def get_siglist(w):
+    if w.alphabet in ["protein", "dayhoff", "hp"]:
+        return os.path.join(out_dir, "protein-input", "{basename}.signatures.txt")
+    else:
+        return os.path.join(out_dir, "dna-input", "{basename}.signatures.txt")
+
+
+rule index_sbt:
+    input: get_siglist 
+    output: os.path.join(out_dir, "index", "{basename}.{alphabet}-k{ksize}-scaled{scaled}.sbt.zip"),
+    threads: 1
+    params:
+        alpha_cmd = lambda w: alphabet_defaults[w.alphabet]["alpha_cmd"],
+        ksize = lambda w: int(w.ksize)*int(alphabet_defaults[w.alphabet]["ksize_multiplier"]),
+    resources:
+        mem_mb=lambda wildcards, attempt: attempt *50000,
+        runtime=6000,
+    log: os.path.join(logs_dir, "index", "{basename}.{alphabet}-k{ksize}-scaled{scaled}.index-sbt.log")
+    benchmark: os.path.join(benchmarks_dir, "index", "{basename}.{alphabet}-k{ksize}-scaled{scaled}.index-sbt.benchmark")
+    conda: "envs/sourmash-dev.yml"
+    shell:
+        """
+        sourmash index {output} --ksize {params.ksize} \
+        --scaled {wildcards.scaled} {params.alpha_cmd}  \
+        --from-file {input}  2> {log}
+        """

--- a/index_config.yml
+++ b/index_config.yml
@@ -1,0 +1,24 @@
+# location for all generated files
+basename: gtdb-r95
+
+output_dir: gtdb-r95
+
+genomes_csv: gtdb-r95/gtdb-r95-reps.lineages.genome-filenames.csv
+proteins_csv: gtdb-r95/gtdb-r95-reps.lineages.protein-filenames.csv
+
+# directory in which genome/protein filenames live
+data_dir: /group/ctbrowngrp/gtdb-r95
+
+alphabet_info:
+  nucleotide:
+    ksizes: [21,31,51]
+    scaled: 2000
+  protein:
+    ksizes: [7,10]
+    scaled: 200
+  dayhoff:
+    ksizes: [16]
+    scaled: 200
+  hp:
+    ksizes: [42]
+    scaled: 200

--- a/index_config.yml
+++ b/index_config.yml
@@ -3,22 +3,23 @@ basename: gtdb-r95
 
 output_dir: gtdb-r95
 
-genomes_csv: gtdb-r95/gtdb-r95-reps.lineages.genome-filenames.csv
-proteins_csv: gtdb-r95/gtdb-r95-reps.lineages.protein-filenames.csv
+genomes_csv: gtdb-r95/gtdb-r95-reps.lineages.genome-filenames.mod.csv
+proteins_csv: gtdb-r95/gtdb-r95-reps.lineages.protein-filenames.mod.csv
 
+protein_input: True
 # directory in which genome/protein filenames live
 data_dir: /group/ctbrowngrp/gtdb-r95
 
 alphabet_info:
   nucleotide:
     ksizes: [21,31,51]
-    scaled: 2000
+    scaled: [2000]
   protein:
     ksizes: [7,10]
-    scaled: 200
+    scaled: [200]
   dayhoff:
     ksizes: [16]
-    scaled: 200
+    scaled: [200]
   hp:
     ksizes: [42]
-    scaled: 200
+    scaled: [200]


### PR DESCRIPTION
Here's a Snakefile for building gtdb (or other) sbts using sourmash 4.0 sketching & indexing. Also added an `environment.yml` with environment than can be used to run this snakefile.

Configfile requires (default `index_config.yml`):
  - genome and/or protein csv with at minimum, `accession, filename` columns
    -  (provide `signame` for better signature naming)
  - `data-dir`:  where to look for the genome/proteome files
  - specify only desired alphabet-ksize-scaled combinations for building sbts.

_To run on different data or with different parameters, modify `index_config.yml` or provide a different configfile._

Alphabet defaults are taken from https://github.com/dib-lab/sourmash/issues/1168.
Workflow does _not_ generate translated sketches, as we don't want to build databases from 6-frame translations.

I also modified the farm sbatch files, and have corresponding snakemake profiles to use, but not sure we want to add those to this repo.


Likely needs modification (e.g. batching?) for even more genomes or additional parameters (bloom filter size?), but here's a starting point for 4.x.

